### PR TITLE
Fix quoting bug in `:file-match`

### DIFF
--- a/setup.el
+++ b/setup.el
@@ -599,7 +599,7 @@ If PATH does not exist, abort the evaluation."
 
 (setup-define :file-match
   (lambda (pat)
-    `(add-to-list 'auto-mode-alist (cons ,pat ,(setup-get 'mode))))
+    `(add-to-list 'auto-mode-alist (cons ,pat ',(setup-get 'mode))))
   :documentation "Associate the current mode with files that match PAT."
   :debug '(form)
   :repeatable t)


### PR DESCRIPTION
`:file-match` forms were throwing `void-variable` errors.  Adding a quote mark fixes it.